### PR TITLE
Add social profiles to user and nonprofit show pages

### DIFF
--- a/app/controllers/nonprofits_controller.rb
+++ b/app/controllers/nonprofits_controller.rb
@@ -25,7 +25,7 @@ class NonprofitsController < ApplicationController
   
   private
     def nonprofit_params
-      params.require(:nonprofit).permit(:name, :website, :email, :phone)
+      params.require(:nonprofit).permit(:name, :website, :email, :phone, social_profile_attributes: [:id, :facebook, :twitter, :instagram, :linked_in])
     end
     
     def authorize_manager

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,9 +1,7 @@
 class RegistrationsController < Devise::RegistrationsController
 
   def new
-    super do |user| 
-      user.managers.build.build_nonprofit
-    end
+    super { |user| user.managers.build.build_nonprofit }
   end
 
   protected

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,7 +1,9 @@
 class RegistrationsController < Devise::RegistrationsController
 
   def new
-    super { |user| user.managers.build.build_nonprofit }
+    super do |user| 
+      user.managers.build.build_nonprofit
+    end
   end
 
   protected
@@ -16,7 +18,7 @@ class RegistrationsController < Devise::RegistrationsController
     end
     
     def account_update_params
-      params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation, :current_password, managers_attributes: [ :id, [nonprofit_attributes: [:id, :name]]])
+      params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation, :current_password, social_profile_attributes: [:id, :facebook, :twitter, :instagram, :linked_in], managers_attributes: [ :id, [nonprofit_attributes: [:id, :name]]])
     end
 
 end

--- a/app/models/nonprofit.rb
+++ b/app/models/nonprofit.rb
@@ -1,4 +1,6 @@
 class Nonprofit < ActiveRecord::Base
   has_many :managers
   has_many :users, through: :managers
+  has_one :social_profile, as: :sociable
+  accepts_nested_attributes_for :social_profile
 end

--- a/app/models/social_profile.rb
+++ b/app/models/social_profile.rb
@@ -1,0 +1,3 @@
+class SocialProfile < ActiveRecord::Base
+  belongs_to :sociable, polymorphic: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,9 +6,12 @@ class User < ActiveRecord::Base
   
   has_many :managers
   has_many :nonprofits, through: :managers
+  has_one :social_profile, as: :sociable
   accepts_nested_attributes_for :managers
+  accepts_nested_attributes_for :social_profile
 
   def can_edit_nonprofit?(nonprofit)
     nonprofit.managers.where(user_id: id).size == 1
   end
+  
 end

--- a/app/views/nonprofits/edit.html.erb
+++ b/app/views/nonprofits/edit.html.erb
@@ -23,8 +23,31 @@
         <%= f.phone_field :phone, class: "form-control", placeholder: "Update phone number" %>
       </div>
       
+      <% @nonprofit.social_profile ||= SocialProfile.new %>
+      <%=f.fields_for :social_profile do |social_profile_form| %>
+        <div class="form-group">
+          <%= social_profile_form.label :facebook, "Facebook Profile" %><br />
+          <%= social_profile_form.url_field :facebook, class: "form-control", placeholder: "Update Facebook URL" %>
+        </div>
+        
+        <div class="form-group">
+          <%= social_profile_form.label :twitter, "Twitter Profile" %><br />
+          <%= social_profile_form.url_field :twitter, class: "form-control", placeholder: "Update Twitter URL" %>
+        </div>
+        
+        <div class="form-group">
+          <%= social_profile_form.label :instagram, "Instagram Profile" %><br />
+          <%= social_profile_form.url_field :instagram, class: "form-control", placeholder: "Update Instagram URL" %>
+        </div>
+        
+        <div class="form-group">
+          <%= social_profile_form.label :linked_in, "LinkedIn Profile" %><br />
+          <%= social_profile_form.url_field :linked_in, class: "form-control", placeholder: "Update LinkedIn URL" %>
+        </div>
+      <% end %>
+      
       <div class="actions">
-        <%= f.submit "Update nonprofit profile", class: "btn btn-success" %>
+        <%= f.submit "Update Nonprofit Profile", class: "btn btn-success" %>
       </div>
       
     <% end %>

--- a/app/views/nonprofits/show.html.erb
+++ b/app/views/nonprofits/show.html.erb
@@ -6,6 +6,24 @@
   <% end %>
 </h1>
 
+<% unless @nonprofit.social_profile.nil? %>
+  <% if @nonprofit.social_profile.facebook.present? %>
+    <%= link_to image_tag("icons/Facebook-48.png", size: "30x30"), @nonprofit.social_profile.facebook %>
+  <% end %>
+  
+  <% if @nonprofit.social_profile.twitter.present? %>
+    <%= link_to image_tag("icons/Twitter-48.png", size: "30x30"), @nonprofit.social_profile.twitter %>
+  <% end %>
+  
+  <% if @nonprofit.social_profile.instagram.present? %>
+    <%= link_to image_tag("icons/Instagram-48.png", size: "30x30"), @nonprofit.social_profile.instagram %>
+  <% end %>
+  
+  <% if @nonprofit.social_profile.linked_in.present? %>
+    <%= link_to image_tag("icons/LinkedIn-48.png", size: "30x30"), @nonprofit.social_profile.linked_in %>
+  <% end %>
+<% end %>
+
 <h3>Contact Information</h3>
 <% unless @nonprofit.website.blank? %>
   <h4>Website: <%= @nonprofit.website %></h4>
@@ -16,4 +34,6 @@
 <% unless @nonprofit.email.blank? %>
   <h4>Email: <%= @nonprofit.email %></h4>
 <% end %>
+
+
 

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -20,6 +20,29 @@
         <%= f.email_field :email, class: "form-control", placeholder: "Update email" %>
       </div>
       
+        <% @user.social_profile ||= SocialProfile.new %>
+        <%= f.fields_for :social_profile do |social_profile_form| %>
+        <div class="form-group">
+          <%= social_profile_form.label :facebook, "Facebook Profile" %><br />
+          <%= social_profile_form.url_field :facebook, class: "form-control", placeholder: "Update Facebook URL" %>
+        </div>
+        
+        <div class="form-group">
+          <%= social_profile_form.label :twitter, "Twitter Profile" %><br />
+          <%= social_profile_form.url_field :twitter, class: "form-control", placeholder: "Update Twitter URL" %>
+        </div>
+        
+        <div class="form-group">
+          <%= social_profile_form.label :instagram, "Instagram Profile" %><br />
+          <%= social_profile_form.url_field :instagram, class: "form-control", placeholder: "Update Instagram URL" %>
+        </div>
+        
+        <div class="form-group">
+          <%= social_profile_form.label :linked_in, "LinkedIn Profile" %><br />
+          <%= social_profile_form.url_field :linked_in, class: "form-control", placeholder: "Update LinkedIn URL" %>
+        </div>
+      <% end %>
+      
         <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
           <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
         <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,1 +1,19 @@
 <h2><%= "#{@user.first_name} #{@user.last_name}" %></h2>
+
+<% unless @user.social_profile.nil? %>
+  <% if @user.social_profile.facebook.present? %>
+    <%= link_to image_tag("icons/Facebook-48.png", size: "30x30"), @user.social_profile.facebook %>
+  <% end %>
+  
+  <% if @user.social_profile.twitter.present? %>
+    <%= link_to image_tag("icons/Twitter-48.png", size: "30x30"), @user.social_profile.twitter %>
+  <% end %>
+  
+  <% if @user.social_profile.instagram.present? %>
+    <%= link_to image_tag("icons/Instagram-48.png", size: "30x30"), @user.social_profile.instagram %>
+  <% end %>
+  
+  <% if @user.social_profile.linked_in.present? %>
+    <%= link_to image_tag("icons/LinkedIn-48.png", size: "30x30"), @user.social_profile.linked_in %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
 
+  get 'social_profiles/index'
+
+  get 'social_profiles/create'
+
   devise_for :users, controllers: { registrations: 'registrations' }
   
   authenticated :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,5 @@
 Rails.application.routes.draw do
 
-  get 'social_profiles/index'
-
-  get 'social_profiles/create'
-
   devise_for :users, controllers: { registrations: 'registrations' }
   
   authenticated :user do

--- a/db/migrate/20160701034208_create_social_profiles.rb
+++ b/db/migrate/20160701034208_create_social_profiles.rb
@@ -1,0 +1,13 @@
+class CreateSocialProfiles < ActiveRecord::Migration
+  def change
+    create_table :social_profiles do |t|
+      t.string :facebook
+      t.string :twitter
+      t.string :instagram
+      t.string :linked_in
+      
+      t.references :sociable, polymorphic: true, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160625183539) do
+ActiveRecord::Schema.define(version: 20160701034208) do
 
   create_table "managers", force: :cascade do |t|
     t.integer  "nonprofit_id"
@@ -31,6 +31,19 @@ ActiveRecord::Schema.define(version: 20160625183539) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  create_table "social_profiles", force: :cascade do |t|
+    t.string   "facebook"
+    t.string   "twitter"
+    t.string   "instagram"
+    t.string   "linked_in"
+    t.integer  "sociable_id"
+    t.string   "sociable_type"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "social_profiles", ["sociable_type", "sociable_id"], name: "index_social_profiles_on_sociable_type_and_sociable_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false

--- a/spec/features/update_nonprofits_spec.rb
+++ b/spec/features/update_nonprofits_spec.rb
@@ -3,30 +3,30 @@ require 'rails_helper'
 RSpec.feature "Update Nonprofits", type: :feature do
   scenario 'successfully' do
   
-  visit '/users/sign_up'
-  
-  within('.np-registration-form') do
-    fill_in 'Organization Name', with: "Ian's Nonprofit"
-    fill_in 'First name', with: 'Ian'
-    fill_in 'Last name', with: 'Roberts'
-    fill_in 'Email', with: 'ianroberts131@gmail.com'
-    fill_in('Password', with: "password", exact: true)
-    fill_in('Password confirmation', with: 'password', exact: true)
-    click_button 'Sign up'
-  end
-  
-  select "Ian's Nonprofit", from: "My Nonprofits"
-  expect(page).to have_text "Edit Nonprofit"
-  fill_in 'Name', with: "New Nonprofit"
-  fill_in 'Email', with: "new_nonprofit@email.com"
-  fill_in 'Website', with: "http://www.new_nonprofit.com"
-  fill_in 'Phone', with: "444-444-4444"
-  click_button 'Update Nonprofit'
-  
-  expect(page).to have_css('h2', text: 'New Nonprofit')
-  expect(page).to have_text("new_nonprofit@email.com")
-  expect(page).to have_text("http://www.new_nonprofit.com")
-  expect(page).to have_text("444-444-4444")
+    visit '/users/sign_up'
+    
+    within('.np-registration-form') do
+      fill_in 'Organization Name', with: "Ian's Nonprofit"
+      fill_in 'First name', with: 'Ian'
+      fill_in 'Last name', with: 'Roberts'
+      fill_in 'Email', with: 'ianroberts131@gmail.com'
+      fill_in('Password', with: "password", exact: true)
+      fill_in('Password confirmation', with: 'password', exact: true)
+      click_button 'Sign up'
+    end
+    
+    click_link "Ian's Nonprofit"
+    click_link 'Edit Nonprofit'
+    fill_in 'Name', with: "New Nonprofit"
+    fill_in 'Email', with: "new_nonprofit@email.com"
+    fill_in 'Website', with: "http://www.new_nonprofit.com"
+    fill_in 'Phone', with: "444-444-4444"
+    click_button 'Update Nonprofit Profile'
+    
+    expect(page).to have_css('h1', text: 'New Nonprofit')
+    expect(page).to have_text("new_nonprofit@email.com")
+    expect(page).to have_text("http://www.new_nonprofit.com")
+    expect(page).to have_text("444-444-4444")
     
   end
 end


### PR DESCRIPTION
Eliot,

I was considering writing a blog post about how I resolved the `fields_for` not displaying social profiles if the `social_profile` for that user had not yet been created. Unlike nonprofits, the social profile is not created at sign-up, so I couldn't use the `build` feature and handle this in the user registration controller. All of the solutions I found online suggested putting `SocialProfile.new` in the `fields_for`, i.e

```
<%= f.fields_for :social_profile, SocialProfile.new do |social_profile_form| %>
```

The problem with this solution is that once I create a path to one (or many) of the social networks, it will be overwritten the next time I go in to edit the profile. I thought a cleaner way was to conditionally create a new social profile only if one didn't exist yet, like this:

```
<% @user.social_profile ||= SocialProfile.new %>
<%= f.fields_for :social_profile do |social_profile_form| %>
```

I figure someone else out there might have the same issue, but if there is a write up out there it isn't easy to find. Do you think the way I handled it is a good solution? And if so, do you think it's blog post worthy?